### PR TITLE
Use the default ESLint version

### DIFF
--- a/tasks/Scaffold/setupEslint.ts
+++ b/tasks/Scaffold/setupEslint.ts
@@ -49,7 +49,7 @@ const task: TaskFn = (_, logger, { absPath, prettier, eslint, pkg }) => {
   /**
    * Setup package.json file
    */
-  pkg.install('eslint@7.32.0')
+  pkg.install('eslint')
   pkg.install('eslint-plugin-adonis')
   pkg.setScript('lint', 'eslint . --ext=.ts')
 


### PR DESCRIPTION
Hey there! 👋🏻 

Forcing the `eslint` version make any AdonisJS's installation fail because our plugin (`eslint-plugin-adonis`) require `eslint@8`.

```
┌ Install dependencies
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: test2@1.0.0
npm ERR! Found: eslint@7.32.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"7.32.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^8.0.0" from eslint-plugin-adonis@2.0.0
npm ERR! node_modules/eslint-plugin-adonis
npm ERR!   dev eslint-plugin-adonis@"2.0.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Removing the hard-coded version remove this issue.